### PR TITLE
Fix ProviderConfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 node_modules/
 types/
 filecache/
+config/

--- a/deno.json
+++ b/deno.json
@@ -7,8 +7,7 @@
         "@std/fs": "jsr:@std/fs@^1.0.11",
         "@std/path": "jsr:@std/path@^1.0.8",
         "react": "npm:react@^19.0.0",
-        "youtube.js": "npm:@sireatsalot/youtube.js@^0.0.4",
-        "currency-symbol-map": "npm:currency-symbol-map"
+        "youtube.js": "npm:@sireatsalot/youtube.js@^0.0.4"
     },
     "tasks": {
     },

--- a/deno.lock
+++ b/deno.lock
@@ -9,7 +9,6 @@
     "jsr:@std/path@^1.0.8": "1.0.8",
     "npm:@sireatsalot/youtube.js@^0.0.4": "0.0.4_axios@1.7.9_tough-cookie@4.1.4_undici@5.28.5",
     "npm:currency-codes@^2.2.0": "2.2.0",
-    "npm:currency-symbol-map@*": "5.1.0",
     "npm:react@19": "19.0.0"
   },
   "jsr": {
@@ -96,9 +95,6 @@
         "first-match",
         "nub"
       ]
-    },
-    "currency-symbol-map@5.1.0": {
-      "integrity": "sha512-LO/lzYRw134LMDVnLyAf1dHE5tyO6axEFkR3TXjQIOmMkAM9YL6QsiUwuXzZAmFnuDJcs4hayOgyIYtViXFrLw=="
     },
     "delayed-stream@1.0.0": {
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
@@ -286,7 +282,6 @@
       "jsr:@std/fs@^1.0.11",
       "jsr:@std/path@^1.0.8",
       "npm:@sireatsalot/youtube.js@^0.0.4",
-      "npm:currency-symbol-map@*",
       "npm:react@19"
     ],
     "packageJson": {

--- a/src/DonationProvider.ts
+++ b/src/DonationProvider.ts
@@ -58,7 +58,7 @@ export enum DonationClass {
  *      constructor(public readonly hello: string) {
  *
  *      }
- * 
+ *
  *      public example = "Hello World!";
  *      public another = 123;
  * }
@@ -81,7 +81,7 @@ export class ProviderConfig {
         return new Proxy(this, {
             set: (target, prop, value) => {
                 target[prop as keyof typeof target] = value;
-                if (prop === "shouldSave") return true;
+                if (prop === 'shouldSave') return true;
                 if (target.shouldSave) target.save();
                 return true;
             },
@@ -117,11 +117,15 @@ export class ProviderConfig {
      * @param savePath Path to load config from
      * @param constructor Config class to construct
      */
-    // deno-lint-ignore no-explicit-any
-    public static async load<T extends ProviderConfig, C extends new (...args: any[]) => T, P extends ConstructorParameters<C>>(constructor: C, ...args: P): Promise<InstanceType<C>> {
+    public static async load<
+        T extends ProviderConfig,
+        // deno-lint-ignore no-explicit-any
+        C extends new (...args: any[]) => T,
+        P extends ConstructorParameters<C>,
+    >(constructor: C, ...args: P): Promise<InstanceType<C>> {
         const config = new constructor(...args) as InstanceType<C>;
         config.shouldSave = false;
-        
+
         try {
             const savePath = config.getSavePath();
 
@@ -143,34 +147,34 @@ export class ProviderConfig {
 }
 
 Deno.test({
-    name: "ProviderConfig",
+    name: 'ProviderConfig',
     fn: async () => {
         class TestConfig extends ProviderConfig {
-            public example = "Hello, world!";
+            public example = 'Hello, world!';
 
             constructor(public test: string) {
                 super('test.json');
             }
         }
 
-        const config = await ProviderConfig.load(TestConfig, "test");
+        const config = await ProviderConfig.load(TestConfig, 'test');
 
-        assertEquals(config.test, "test");
+        assertEquals(config.test, 'test');
 
-        config.test = "tested";
+        config.test = 'tested';
 
-        assertEquals(config.test, "tested");
+        assertEquals(config.test, 'tested');
 
         const configFile = JSON.parse(await Deno.readTextFile(join(ProviderConfig.configPath, 'test.json')));
 
         assertEquals(configFile.savePath, undefined);
-        assertEquals(configFile.test, "tested", "value in config file does not reflect changed value.");
-        assertEquals(configFile.example, "Hello, world!", "value in config file does not reflect unchanged value.");
+        assertEquals(configFile.test, 'tested', 'value in config file does not reflect changed value.');
+        assertEquals(configFile.example, 'Hello, world!', 'value in config file does not reflect unchanged value.');
 
-        const loadedConfig = await ProviderConfig.load(TestConfig, "test");
-        assertEquals(loadedConfig.test, "tested", "changed value in config file not properly set on load.");
+        const loadedConfig = await ProviderConfig.load(TestConfig, 'test');
+        assertEquals(loadedConfig.test, 'tested', 'changed value in config file not properly set on load.');
 
         // cleanup
         await Deno.remove(join(ProviderConfig.configPath, 'test.json'));
-    }
+    },
 });

--- a/src/DonationProvider.ts
+++ b/src/DonationProvider.ts
@@ -172,8 +172,7 @@ Deno.test({
         const configPath = config.getSavePath();
         
         const configFile = JSON.parse(await Deno.readTextFile(configPath));
-
-        assertEquals(configFile.savePath, undefined);
+        
         assertEquals(configFile.test, 'tested', 'value in config file does not reflect changed value.');
         assertEquals(configFile.unchanged, 'unchanged', 'value in config file does not reflect unchanged value.');
 

--- a/src/DonationProvider.ts
+++ b/src/DonationProvider.ts
@@ -141,6 +141,7 @@ export class ProviderConfig {
         } catch (error) {
             // file doesn't exist or old JSON is corruped; we wanna create a new config instead.
             console.warn(`Error loading config for ${constructor.name}: ${error}. Using defaults instead.`);
+            config.shouldSave = true;
             return config;
         }
     }

--- a/src/DonationProvider.ts
+++ b/src/DonationProvider.ts
@@ -1,6 +1,7 @@
 import { CurrencyCodeRecord } from 'currency-codes';
 import { LocallyCachedImage } from '@/ImageCache.ts';
 import { join } from '@std/path/join';
+import { assertEquals } from '@std/assert/equals';
 
 export interface DonationProvider {
     readonly name: string;
@@ -54,22 +55,34 @@ export enum DonationClass {
  * @example
  * ```ts
  * class ExampleConfig extends ProviderConfig {
+ *      constructor(public readonly hello: string) {
+ *
+ *      }
+ * 
  *      public example = "Hello World!";
  *      public another = 123;
  * }
  *
- * const config = await ProviderConfig.load("example.json", ExampleConfig);
+ * const config = await ProviderConfig.load(ExampleConfig, "hi!");
  *
  * // Setting a property automatically causes a synchronous save.
  * config.example = "Goodbye World!";
  * ```
  */
 export class ProviderConfig {
+    static configPath = join(Deno.cwd(), 'config');
+
+    /**
+     * Internally used to keep track of whether a save/load is currently in progress.
+     */
+    private shouldSave = false;
+
     constructor(protected savePath: string) {
         return new Proxy(this, {
             set: (target, prop, value) => {
-                Reflect.set(target, prop, value);
-                target.save();
+                target[prop as keyof typeof target] = value;
+                if (prop === "shouldSave") return true;
+                if (target.shouldSave) target.save();
                 return true;
             },
         });
@@ -80,36 +93,84 @@ export class ProviderConfig {
      * This is automatically called every time a property is set.
      */
     public save(): void {
+        this.shouldSave = false;
         const copy = structuredClone(this);
         Reflect.deleteProperty(copy, 'savePath');
+        Reflect.deleteProperty(copy, 'shouldSave');
 
-        const savePath = join(Deno.cwd(), 'config', this.savePath);
+        const savePath = this.getSavePath();
 
         // ensure config folder exists
-        Deno.mkdirSync(join(Deno.cwd(), 'config'));
+        Deno.mkdirSync(ProviderConfig.configPath, { recursive: true });
         Deno.writeTextFileSync(savePath, JSON.stringify(copy));
+        this.shouldSave = true;
+    }
+
+    private getSavePath(): string {
+        return join(ProviderConfig.configPath, this.savePath);
     }
 
     /**
-     * Load the config from disk at the path specified by `savePath`.
+     * Load the config from disk, or create a new one if it doesn't exist.
      *
      * Constructing a config class directly without going through `load` will lead to unexpected behaviour.
      * @param savePath Path to load config from
      * @param constructor Config class to construct
      */
-    public static async load<T>(savePath: string, constructor: new (savePath: string) => T): Promise<T> {
+    // deno-lint-ignore no-explicit-any
+    public static async load<T extends ProviderConfig, C extends new (...args: any[]) => T, P extends ConstructorParameters<C>>(constructor: C, ...args: P): Promise<InstanceType<C>> {
+        const config = new constructor(...args) as InstanceType<C>;
+        config.shouldSave = false;
+        
         try {
+            const savePath = config.getSavePath();
+
             const json = JSON.parse(await Deno.readTextFile(savePath));
-            const config = new constructor(savePath);
 
             for (const [key, value] of Object.entries(json)) {
                 Reflect.set(config as object, key, value);
             }
 
+            config.shouldSave = true;
+
             return config;
-        } catch {
+        } catch (error) {
             // file doesn't exist or old JSON is corruped; we wanna create a new config instead.
-            return new constructor(savePath);
+            console.warn(`Error loading config for ${constructor.name}: ${error}. Using defaults instead.`);
+            return config;
         }
     }
 }
+
+Deno.test({
+    name: "ProviderConfig",
+    fn: async () => {
+        class TestConfig extends ProviderConfig {
+            public example = "Hello, world!";
+
+            constructor(public test: string) {
+                super('test.json');
+            }
+        }
+
+        const config = await ProviderConfig.load(TestConfig, "test");
+
+        assertEquals(config.test, "test");
+
+        config.test = "tested";
+
+        assertEquals(config.test, "tested");
+
+        const configFile = JSON.parse(await Deno.readTextFile(join(ProviderConfig.configPath, 'test.json')));
+
+        assertEquals(configFile.savePath, undefined);
+        assertEquals(configFile.test, "tested", "value in config file does not reflect changed value.");
+        assertEquals(configFile.example, "Hello, world!", "value in config file does not reflect unchanged value.");
+
+        const loadedConfig = await ProviderConfig.load(TestConfig, "test");
+        assertEquals(loadedConfig.test, "tested", "changed value in config file not properly set on load.");
+
+        // cleanup
+        await Deno.remove(join(ProviderConfig.configPath, 'test.json'));
+    }
+});

--- a/src/DonationProvider.ts
+++ b/src/DonationProvider.ts
@@ -49,8 +49,8 @@ export enum DonationClass {
     Red5,
 }
 
-const SHOULD_SAVE = Symbol("shouldSave");
-const SAVE_PATH = Symbol("savePath");
+const SHOULD_SAVE = Symbol('shouldSave');
+const SAVE_PATH = Symbol('savePath');
 
 /**
  * Base class for all provider configs.
@@ -87,7 +87,7 @@ export class ProviderConfig {
             set: (target, prop, value) => {
                 target[prop as keyof typeof target] = value;
                 // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
-                if (typeof prop === "symbol") return true;
+                if (typeof prop === 'symbol') return true;
                 if (target[SHOULD_SAVE]) target.save();
                 return true;
             },
@@ -151,7 +151,6 @@ export class ProviderConfig {
     }
 }
 
-
 class TestConfig extends ProviderConfig {
     public test = 'Hello, world!';
     public unchanged = 'unchanged';
@@ -166,13 +165,13 @@ Deno.test({
     fn: async () => {
         const config = await ProviderConfig.load(TestConfig);
 
-        config.test = "tested";
+        config.test = 'tested';
 
         // @ts-expect-error accessing private method for testing reasons
         const configPath = config.getSavePath();
-        
+
         const configFile = JSON.parse(await Deno.readTextFile(configPath));
-        
+
         assertEquals(configFile.test, 'tested', 'value in config file does not reflect changed value.');
         assertEquals(configFile.unchanged, 'unchanged', 'value in config file does not reflect unchanged value.');
 
@@ -185,7 +184,7 @@ Deno.test({
     name: 'ProviderConfig: load',
     fn: async () => {
         const exampleConfig = {
-            test: "tested",
+            test: 'tested',
         };
 
         const configPath = join(ProviderConfig.configPath, 'test.json');
@@ -193,11 +192,11 @@ Deno.test({
 
         const config = await ProviderConfig.load(TestConfig);
 
-        assertEquals(config.test, exampleConfig.test, "property with default value not overwritten by config file.");
+        assertEquals(config.test, exampleConfig.test, 'property with default value not overwritten by config file.');
         assertEquals(config.unchanged, 'unchanged', "property that's not part of the config file changed.");
 
         await Deno.remove(configPath);
-    }
+    },
 });
 
 Deno.test({
@@ -205,16 +204,16 @@ Deno.test({
     fn: async () => {
         class TestConfig extends ProviderConfig {
             constructor(public readonly thing: number) {
-                super("test.json");
+                super('test.json');
             }
         }
 
         // @ts-expect-error should give a compile error for wrong/missing constructor arguments
         await ProviderConfig.load(TestConfig);
         // @ts-expect-error should give a compile error for wrong/missing constructor arguments
-        await ProviderConfig.load(TestConfig, "hello, world!");
+        await ProviderConfig.load(TestConfig, 'hello, world!');
 
         const config = await ProviderConfig.load(TestConfig, 1);
-        assertEquals(config.thing, 1, "argument not passed to constructor.");
-    }
+        assertEquals(config.thing, 1, 'argument not passed to constructor.');
+    },
 });

--- a/src/chat_providers/YouTube.ts
+++ b/src/chat_providers/YouTube.ts
@@ -24,7 +24,7 @@ export class YouTubeDonationProvider implements DonationProvider {
 
     async activate(): Promise<boolean> {
         try {
-            this.config = await ProviderConfig.load(YouTubeConfig, "youtube.js");
+            this.config = await ProviderConfig.load(YouTubeConfig, 'youtube.js');
             await this.client.init();
 
             this.shouldStop = false;

--- a/src/chat_providers/YouTube.ts
+++ b/src/chat_providers/YouTube.ts
@@ -24,7 +24,7 @@ export class YouTubeDonationProvider implements DonationProvider {
 
     async activate(): Promise<boolean> {
         try {
-            this.config = await ProviderConfig.load(YouTubeConfig, 'youtube.js');
+            this.config = await ProviderConfig.load(YouTubeConfig, 'youtube.json');
             await this.client.init();
 
             this.shouldStop = false;

--- a/src/chat_providers/YouTube.ts
+++ b/src/chat_providers/YouTube.ts
@@ -3,9 +3,7 @@ import { ScrapingClient } from 'youtube.js';
 import { ChatMessage, MessageType } from 'youtube.js/dist/scraping/ChatClient.js';
 import { LocallyCachedImage } from '@/ImageCache.ts';
 import { code } from 'currency-codes';
-import currencyCodeMap from 'currency-symbol-map/map.js';
-
-const reverseCurrencyCodeMap = Object.fromEntries(Object.entries(currencyCodeMap).map(([key, value]) => [value, key]));
+import { getCurrencyCodeFromString } from '@/CurrencyConversion.ts';
 
 export class YouTubeDonationProvider implements DonationProvider {
     name = 'YouTube';
@@ -26,7 +24,7 @@ export class YouTubeDonationProvider implements DonationProvider {
 
     async activate(): Promise<boolean> {
         try {
-            this.config = await ProviderConfig.load('youtube.json', YouTubeConfig);
+            this.config = await ProviderConfig.load(YouTubeConfig, "youtube.js");
             await this.client.init();
 
             this.shouldStop = false;
@@ -84,11 +82,11 @@ export class YouTubeDonationProvider implements DonationProvider {
                 donationMessage.messageType = 'text';
                 donationMessage.donationAmount = message.amount;
 
-                const currencyCode = reverseCurrencyCodeMap[message.currency];
+                const currencyCode = getCurrencyCodeFromString(message.currency);
                 if (!currencyCode) {
                     throw new Error('SHIT FUCK SHIT SHIT FUCK');
                 }
-                donationMessage.donationCurrency = code(currencyCode);
+                donationMessage.donationCurrency = currencyCode;
                 // temporarily set to blue while we figure out details of `DonationClass`
                 donationMessage.donationClass = DonationClass.Blue;
                 break;


### PR DESCRIPTION
Fixes some issues with the `ProviderConfig` class I wrote.
Namely:
- loads now work properly and don't overwrite existing files (whoops!)
- loads and saves now use the same file (whoops again!)
- adds some type shenanigans so `ProviderConfig.load` now supports passing constructor arguments

(also migrates the YouTube provider to the new currency conversion system cuz I was already messing with it)