### PR TITLE
allow `SavedConfig` to also trap and save on nested property sets

### DIFF
--- a/src/SavedConfig.test.ts
+++ b/src/SavedConfig.test.ts
@@ -79,11 +79,7 @@ Deno.test(`${testPrefix} Validation failure during load`, async () => {
 interface serviceInterface {
     John: number
     Shiki: string
-    Eats: Error
-}
-
-class serviceClass {
-    returnTrue = () => true
+    Eats: { message: string }
 }
 
 class ComplicatedConfig extends SavedConfig {
@@ -92,11 +88,10 @@ class ComplicatedConfig extends SavedConfig {
         "foo": 1,
         "bar": 2
     }
-    map: Map<number, string> = new Map<number, string>()
     service: serviceInterface = {
         John: 1,
         Shiki: "oshi",
-        Eats: new Deno.errors.Busy("Eating burgers")
+        Eats: { message: "Eating burgers" },
     }
     nested: Record<string, Record<string, Record<string, number>>> = {
         one: {
@@ -106,13 +101,10 @@ class ComplicatedConfig extends SavedConfig {
         }
     }
     array = ["six", "seven", "eight"]
-    complexType = new serviceClass()
 }
 
 Deno.test({
     name: `${testPrefix} Complicated Config`,
-    // This test currently doesn't work. Deeper proxying or some other solution will be needed.
-    ignore: true,
     fn: async () => {
         let config = await SavedConfig.getOrCreate(ComplicatedConfig);
         config.nested["one"]["two"]["three"] = 9
@@ -120,11 +112,6 @@ Deno.test({
         config.array[2] = "ten"
 
         config = await SavedConfig.getOrCreate(ComplicatedConfig);
-        try {
-            config.complexType.returnTrue()
-        } catch {
-            throw new Error("Failure to rehydrate type")
-        }
         assertEquals(
             config.array[2],
             "ten", "Array change failure"

--- a/src/SavedConfig.ts
+++ b/src/SavedConfig.ts
@@ -3,6 +3,8 @@ import { join } from '@std/path';
 const SHOULD_SAVE = Symbol('shouldSave');
 export const SAVE_PATH = Symbol('savePath');
 
+const HAS_BEEN_PROXIED = Symbol("hasBeenProxied");
+
 /**
  * Base class for all on-disk automatically saving configs.
  *
@@ -29,35 +31,84 @@ export abstract class SavedConfig {
     protected abstract [SAVE_PATH]: string;
 
     constructor() {
-        return new Proxy(this, {
-            set: (target, prop, value) => {
-                // Enforce CCTOR-only setting of SAVE_PATH
-                if (target[SAVE_PATH] && prop == SAVE_PATH) {
-                    throw new Error("Setting [SAVE_PATH] not allowed outside of cctor")
-                }
-                // Store the current value.
-                const oldvalue = target[prop as keyof typeof target]
-                try {
-                    // Set the value (can't forget to do that)
+        const replacePropertiesWithProxy = <T>(target: T) => {
+            if ((target as { [HAS_BEEN_PROXIED]?: boolean })[HAS_BEEN_PROXIED]) {
+                return;
+            }
+            for (const [key, value] of Object.entries(target as object)) {
+                if (typeof value === "object") {
+                    // I can't think of a better way to cast this, so this will have to do.
+                    // deno-lint-ignore no-explicit-any
+                    (target as any)[key] = new Proxy(value, {
+                        set: setCallback
+                    });
+
+                    replacePropertiesWithProxy(value);
+                } 
+            }
+
+            // since this property is *only* used for preventing duplicate work and should only ever be defined,
+            // never written to, we completely hide and freeze it.
+            Object.defineProperty(target, HAS_BEEN_PROXIED, {
+                value: true,
+                enumerable: false,
+                configurable: false,
+                writable: false,
+            });
+        }
+
+        // deno-lint-ignore no-explicit-any
+        const setCallback = <T>(target: T, prop: string | symbol, value: any): boolean => {
+            // I'm, honestly not sure why this is needed but I assume it's something to do
+            // with child class initializers. Without it, the complicated test case fails,
+            // so I'll just leave it in for now - Eats
+            replacePropertiesWithProxy(target);
+
+            // Enforce CCTOR-only setting of SAVE_PATH
+            if (this[SAVE_PATH] && prop == SAVE_PATH) {
+                throw new Error("Setting [SAVE_PATH] not allowed outside of cctor")
+            }
+            // Store the current value.
+            const oldvalue = target[prop as keyof typeof target];
+            try {
+                // Set the value (can't forget to do that)
+                if (typeof value === "object") {
+                    // The object we're given here was fully instantiated and might itself have object-type properties.
+                    // So we look for those and replace them with our setter Proxy.
+                    replacePropertiesWithProxy(value);
+                    // if the value is an object, we want to trap any sets to it similar to how we trap
+                    // sets on the root object.
+                    target[prop as keyof typeof target] = new Proxy(value, {
+                        set: (target, prop, value) => {
+                            return setCallback(target, prop, value);
+                        }
+                    });
+                } else {
                     target[prop as keyof typeof target] = value;
-                    if (target[SHOULD_SAVE]) {
-                        // Only validate if saving is enabled. If saving is disabled, we're probably operating
-                        // in internal plumbing and a validation pass will happen afterwards.
-                        target.validate()
-                    }
-                } catch (e) {
-                    // Validation failed. Reset to old value, print the error to the console, and return false
-                    target[prop as keyof typeof target] = oldvalue
-                    console.error((e as Error).message)
-                    return false
                 }
-                // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
-                if (typeof prop === 'symbol') return true;
-                if (target[SHOULD_SAVE]) target.save();
-                return true;
-            },
+
+                if (this[SHOULD_SAVE]) {
+                    // Only validate if saving is enabled. If saving is disabled, we're probably operating
+                    // in internal plumbing and a validation pass will happen afterwards.
+                    this.validate()
+                }
+            } catch (e) {
+                // Validation failed. Reset to old value, print the error to the console, and return false
+                target[prop as keyof typeof target] = oldvalue
+                console.error((e as Error).message)
+                return false
+            }
+            // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
+            if (typeof prop === 'symbol') return true;
+            if (this[SHOULD_SAVE]) this.save();
+            return true;
+        };
+
+        return new Proxy(this, {
+            set: setCallback,
         });
     }
+
 
     /**
      * Save the config to disk at the path specified by `savePath`.

--- a/src/SavedConfig.ts
+++ b/src/SavedConfig.ts
@@ -37,13 +37,13 @@ export abstract class SavedConfig {
             }
             for (const [key, value] of Object.entries(target as object)) {
                 if (typeof value === "object") {
-                    replacePropertiesWithProxy(value);
-                    
                     // I can't think of a better way to cast this, so this will have to do.
                     // deno-lint-ignore no-explicit-any
                     (target as any)[key] = new Proxy(value, {
                         set: setCallback
                     });
+
+                    replacePropertiesWithProxy(value);
                 } 
             }
 
@@ -68,10 +68,6 @@ export abstract class SavedConfig {
             if (this[SAVE_PATH] && prop == SAVE_PATH) {
                 throw new Error("Setting [SAVE_PATH] not allowed outside of cctor")
             }
-            
-            // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
-            if (typeof prop === 'symbol') return true;
-            
             // Store the current value.
             const oldvalue = target[prop as keyof typeof target];
             try {
@@ -102,7 +98,8 @@ export abstract class SavedConfig {
                 console.error((e as Error).message)
                 return false
             }
-
+            // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
+            if (typeof prop === 'symbol') return true;
             if (this[SHOULD_SAVE]) this.save();
             return true;
         };

--- a/src/SavedConfig.ts
+++ b/src/SavedConfig.ts
@@ -32,7 +32,7 @@ export abstract class SavedConfig {
 
     constructor() {
         const replacePropertiesWithProxy = <T>(target: T) => {
-            if ((target as { [HAS_BEEN_PROXIED]?: boolean })[HAS_BEEN_PROXIED]) {
+            if (!target || (target as { [HAS_BEEN_PROXIED]?: boolean })[HAS_BEEN_PROXIED]) {
                 return;
             }
             for (const [key, value] of Object.entries(target as object)) {
@@ -76,7 +76,7 @@ export abstract class SavedConfig {
             const oldvalue = target[prop as keyof typeof target];
             try {
                 // Set the value (can't forget to do that)
-                if (typeof value === "object") {
+                if (value && typeof value === "object") {
                     // The object we're given here was fully instantiated and might itself have object-type properties.
                     // So we look for those and replace them with our setter Proxy.
                     replacePropertiesWithProxy(value);
@@ -102,7 +102,7 @@ export abstract class SavedConfig {
                 console.error((e as Error).message)
                 return false
             }
-            
+
             if (this[SHOULD_SAVE]) this.save();
             return true;
         };

--- a/src/SavedConfig.ts
+++ b/src/SavedConfig.ts
@@ -37,13 +37,13 @@ export abstract class SavedConfig {
             }
             for (const [key, value] of Object.entries(target as object)) {
                 if (typeof value === "object") {
+                    replacePropertiesWithProxy(value);
+                    
                     // I can't think of a better way to cast this, so this will have to do.
                     // deno-lint-ignore no-explicit-any
                     (target as any)[key] = new Proxy(value, {
                         set: setCallback
                     });
-
-                    replacePropertiesWithProxy(value);
                 } 
             }
 
@@ -68,6 +68,10 @@ export abstract class SavedConfig {
             if (this[SAVE_PATH] && prop == SAVE_PATH) {
                 throw new Error("Setting [SAVE_PATH] not allowed outside of cctor")
             }
+            
+            // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
+            if (typeof prop === 'symbol') return true;
+            
             // Store the current value.
             const oldvalue = target[prop as keyof typeof target];
             try {
@@ -98,8 +102,7 @@ export abstract class SavedConfig {
                 console.error((e as Error).message)
                 return false
             }
-            // Symbol keys can't be persisted to disk, and they're used for internal state tracking as well. So we ignore them as save candidates.
-            if (typeof prop === 'symbol') return true;
+            
             if (this[SHOULD_SAVE]) this.save();
             return true;
         };


### PR DESCRIPTION
Like #7 but not like, wrong. And also fixed. Don't git without coffee, kids.